### PR TITLE
`ark-cli`: Depend on Workspace Crates Instead of `arklib`

### DIFF
--- a/ark-cli/Cargo.toml
+++ b/ark-cli/Cargo.toml
@@ -5,18 +5,26 @@ edition = "2021"
 
 [[bin]]
 name = "ark-cli"
+bench = false
 
 [dependencies]
 tokio = { version = "1.35.1", features = ["full"] }
-arklib = { git = "https://github.com/ARK-Builders/arklib", branch = "ark-rust_hot_fix" }
 clap = { version = "3.0.10", features = ["derive"] }
 env_logger = "0.9.0"
 fs_extra = "1.2.0"
-walkdir = "2.3.2"
 home = "0.5.3"
 url = { version = "2.2.2", features = ["serde"] }
 serde_json = "1.0.82"
-serde = { version = "1.0.138", features = ["derive"] }
 chrono = "0.4.34"
 anyhow = "1.0.80"
 thiserror = "1.0.57"
+
+data-error = { path = "../data-error" }
+data-link = { path = "../data-link" }
+data-pdf = { path = "../data-pdf" }
+data-resource = { path = "../data-resource" }
+fs-atomic-versions = { path = "../fs-atomic-versions" }
+fs-metadata = { path = "../fs-metadata" }
+fs-properties = { path = "../fs-properties" }
+fs-index = { path = "../fs-index" }
+fs-storage = { path = "../fs-storage" }

--- a/ark-cli/src/commands/file.rs
+++ b/ark-cli/src/commands/file.rs
@@ -1,6 +1,7 @@
 use crate::error::AppError;
 use crate::models::{format, format::Format};
-use arklib::{modify, modify_json, AtomicFile, Result as ArklibResult};
+use data_error::Result as ArklibResult;
+use fs_atomic_versions::atomic::{modify, modify_json, AtomicFile};
 
 pub fn file_append(
     atomic_file: &AtomicFile,

--- a/ark-cli/src/commands/link.rs
+++ b/ark-cli/src/commands/link.rs
@@ -1,4 +1,5 @@
-use arklib::{id::ResourceId, link::Link};
+use data_link::Link;
+use data_resource::ResourceId;
 use std::path::PathBuf;
 use url::Url;
 
@@ -50,5 +51,5 @@ pub fn load_link(
         ))?,
     }?;
 
-    Ok(arklib::link::Link::load(root, &path)?)
+    Ok(Link::load(root, &path)?)
 }

--- a/ark-cli/src/error.rs
+++ b/ark-cli/src/error.rs
@@ -1,4 +1,4 @@
-use arklib::ArklibError;
+use data_error::ArklibError;
 use std::io;
 use thiserror::Error;
 

--- a/ark-cli/src/main.rs
+++ b/ark-cli/src/main.rs
@@ -3,9 +3,11 @@ use std::io::{Read, Write};
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use arklib::id::ResourceId;
-use arklib::pdf::PDFQuality;
-use arklib::{app_id, provide_index};
+use data_pdf::{render_preview_page, PDFQuality};
+use data_resource::ResourceId;
+use fs_atomic_versions::app_id;
+use fs_index::provide_index;
+use fs_storage::ARK_FOLDER;
 
 use chrono::prelude::DateTime;
 use chrono::Utc;
@@ -422,7 +424,7 @@ async fn main() -> anyhow::Result<()> {
                     options.copy_inside = true;
 
                     let result = dir::copy(
-                        root.join(arklib::ARK_FOLDER),
+                        root.join(ARK_FOLDER),
                         storage_backup,
                         &options,
                     );
@@ -457,7 +459,7 @@ async fn main() -> anyhow::Result<()> {
                     .to_owned()
                     + ".png",
             );
-            let img = arklib::pdf::render_preview_page(buf, quality);
+            let img = render_preview_page(buf, quality);
             img.save(dest_path).unwrap();
         }
         Command::Link(link) => match &link {

--- a/ark-cli/src/models/cli.rs
+++ b/ark-cli/src/models/cli.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use arklib::id::ResourceId;
 use clap::{Parser, Subcommand};
+use data_resource::ResourceId;
 
 use super::{
     entry::EntryOutput, format::Format, sort::Sort, storage::StorageType,

--- a/ark-cli/src/models/storage.rs
+++ b/ark-cli/src/models/storage.rs
@@ -1,4 +1,5 @@
-use arklib::{id::ResourceId, AtomicFile};
+use data_resource::ResourceId;
+use fs_atomic_versions::atomic::AtomicFile;
 use std::fmt::Write;
 use std::path::PathBuf;
 

--- a/ark-cli/src/util.rs
+++ b/ark-cli/src/util.rs
@@ -1,8 +1,9 @@
-use arklib::id::ResourceId;
-use arklib::index::ResourceIndex;
-use arklib::{
-    ARK_FOLDER, METADATA_STORAGE_FOLDER, PREVIEWS_STORAGE_FOLDER,
-    PROPERTIES_STORAGE_FOLDER, SCORE_STORAGE_FILE, STATS_FOLDER,
+use data_resource::ResourceId;
+use fs_index::index::ResourceIndex;
+use fs_metadata::METADATA_STORAGE_FOLDER;
+use fs_properties::PROPERTIES_STORAGE_FOLDER;
+use fs_storage::{
+    ARK_FOLDER, PREVIEWS_STORAGE_FOLDER, SCORE_STORAGE_FILE, STATS_FOLDER,
     TAG_STORAGE_FILE, THUMBNAILS_STORAGE_FOLDER,
 };
 use std::env::current_dir;
@@ -71,7 +72,7 @@ pub fn provide_root(root_dir: &Option<PathBuf>) -> Result<PathBuf, AppError> {
 // Read-only structure
 pub fn provide_index(root_dir: &PathBuf) -> ResourceIndex {
     let rwlock =
-        arklib::provide_index(root_dir).expect("Failed to retrieve index");
+        fs_index::provide_index(root_dir).expect("Failed to retrieve index");
     let index = &*rwlock.read().unwrap();
     index.clone()
 }
@@ -85,7 +86,7 @@ pub fn monitor_index(
     println!("Building index of folder {}", dir_path.display());
     let start = Instant::now();
 
-    let result = arklib::provide_index(dir_path);
+    let result = fs_index::provide_index(dir_path);
     let duration = start.elapsed();
 
     match result {
@@ -132,7 +133,7 @@ pub fn monitor_index(
 }
 
 pub fn storages_exists(path: &Path) -> bool {
-    let meta = metadata(path.join(arklib::ARK_FOLDER));
+    let meta = metadata(path.join(ARK_FOLDER));
     if let Ok(meta) = meta {
         return meta.is_dir();
     }


### PR DESCRIPTION
## Description 
This PR removes `ark-cli` dependency on `arklib` and depends on other `ark-rust` crates from the workspace.
This should be the last step of merging `ark-cli` into `ark-rust` cargo workspace. 

Fixes #15 

## Next steps:
- move unresolved issues from both repositories to `ark-rust` 
- archive both `arklib` and `ark-cli` 


## Other changes:
- disable benches for `ark-cli`
- remove unused `ark-cli` unused crate dependencies