### PR TITLE
Update `FileStorage` write to disk format to valid JSON

### DIFF
--- a/fs-storage/src/file_storage.rs
+++ b/fs-storage/src/file_storage.rs
@@ -39,7 +39,7 @@ where
     K: Ord,
 {
     version: i32,
-    data: BTreeMap<K, V>,
+    entries: BTreeMap<K, V>,
 }
 
 impl<K, V> FileStorage<K, V>
@@ -62,12 +62,12 @@ where
             timestamp: SystemTime::now(),
             data: FileStorageData {
                 version: STORAGE_VERSION,
-                data: BTreeMap::new(),
+                entries: BTreeMap::new(),
             },
         };
 
         // Load the data from the file
-        file_storage.data.data = match file_storage.read_fs() {
+        file_storage.data.entries = match file_storage.read_fs() {
             Ok(data) => data,
             Err(_) => BTreeMap::new(),
         };
@@ -88,14 +88,14 @@ where
         + std::str::FromStr,
 {
     fn set(&mut self, id: K, value: V) {
-        self.data.data.insert(id, value);
+        self.data.entries.insert(id, value);
         self.timestamp = std::time::SystemTime::now();
         self.write_fs()
             .expect("Failed to write data to disk");
     }
 
     fn remove(&mut self, id: &K) -> Result<()> {
-        self.data.data.remove(id).ok_or_else(|| {
+        self.data.entries.remove(id).ok_or_else(|| {
             ArklibError::Storage(self.label.clone(), "Key not found".to_owned())
         })?;
         self.timestamp = std::time::SystemTime::now();
@@ -162,7 +162,7 @@ where
         }
         self.timestamp = fs::metadata(&self.path)?.modified()?;
 
-        Ok(data.data)
+        Ok(data.entries)
     }
 
     fn write_fs(&mut self) -> Result<()> {
@@ -187,7 +187,7 @@ where
         log::info!(
             "{} {} entries have been written",
             self.label,
-            self.data.data.len()
+            self.data.entries.len()
         );
         Ok(())
     }
@@ -204,7 +204,7 @@ where
     K: Ord,
 {
     fn as_ref(&self) -> &BTreeMap<K, V> {
-        &self.data.data
+        &self.data.entries
     }
 }
 

--- a/fs-storage/src/lib.rs
+++ b/fs-storage/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod base_storage;
 pub mod file_storage;
+mod utils;
 pub const ARK_FOLDER: &str = ".ark";
 
 // Should not be lost if possible

--- a/fs-storage/src/utils.rs
+++ b/fs-storage/src/utils.rs
@@ -1,0 +1,82 @@
+use data_error::Result;
+use std::collections::BTreeMap;
+use std::path::Path;
+
+/// Parses version 2 `FileStorage` format and returns the data as a BTreeMap
+///
+/// Version 2 `FileStorage` format represents data as a BTreeMap in plaintext.
+///
+/// For example:
+/// ```text
+/// version: 2
+/// key1:1
+/// key2:2
+/// key3:3
+/// ```
+pub fn read_version_2_fs<K, V>(path: &Path) -> Result<BTreeMap<K, V>>
+where
+    K: Ord
+        + Clone
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+        + std::str::FromStr,
+    V: Clone
+        + serde::Serialize
+        + serde::de::DeserializeOwned
+        + std::str::FromStr,
+{
+    // First check if the file starts with "version: 2"
+    let file_content = std::fs::read_to_string(path)?;
+    if !file_content.starts_with("version: 2") {
+        return Err(data_error::ArklibError::Parse);
+    }
+
+    // Parse the file content into a BTreeMap
+    let mut data = BTreeMap::new();
+    for line in file_content.lines().skip(1) {
+        let mut parts = line.split(':');
+        let key = parts
+            .next()
+            .unwrap()
+            .parse()
+            .map_err(|_| data_error::ArklibError::Parse)?;
+        let value = parts
+            .next()
+            .unwrap()
+            .parse()
+            .map_err(|_| data_error::ArklibError::Parse)?;
+
+        data.insert(key, value);
+    }
+
+    Ok(data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempdir::TempDir;
+
+    /// Test reading a legacy version 2 `FileStorage` file
+    #[test]
+    fn test_read_legacy_fs() {
+        let temp_dir = TempDir::new("ark-rust").unwrap();
+        let file_path = temp_dir.path().join("test_read_legacy_fs");
+        let file_content = r#"version: 2
+key1:1
+key2:2
+key3:3
+"#;
+        let mut file = std::fs::File::create(&file_path).unwrap();
+        file.write_all(file_content.as_bytes()).unwrap();
+
+        // Read the file and check the data
+        let data: BTreeMap<String, i32> =
+            read_version_2_fs(&file_path).unwrap();
+        assert_eq!(data.len(), 3);
+        assert_eq!(data.get("key1"), Some(&1));
+        assert_eq!(data.get("key2"), Some(&2));
+        assert_eq!(data.get("key3"), Some(&3));
+    }
+}


### PR DESCRIPTION
## Description
This pull request addresses the issue where the write to disk format for `FileStorage` was not valid JSON:
- #38

## Changes
Previously, the format looked like this:
```
version 2
{"a":"1","b":"2"}
```
After this pull request, the format will be updated to the following valid JSON format:
```
{
  "version": 3,
  "data": {
    "a": "1",
    "b": "2",
    "c": "3"
  }
}
```
In addition to fixing the format, this pull request also bumps the version to 3 (JSON).

Furthermore, support for reading the legacy version 2 plaintext `FileStorage` format is added for backwards compatibility. This is achieved through the addition of a helper function `read_version_2_fs`, along with a unit test.