### PR TITLE
Update GitHub Workflows to Use `macos-latest`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
 
   mac-intel:
     name: Test on macOS Intel
-    runs-on: macos-11
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -37,7 +37,7 @@ jobs:
 
   mac-intel:
     name: MacOS Intel
-    runs-on: macos-11
+    runs-on: macos-14
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description
The macOS 11 runner image will be removed by June 28, 2024. 
This PR updates the GitHub workflows to use `macos-latest` instead of `macos-11`.



More context: https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/#macos-11-deprecation-and-removal