### PR TITLE
Weird bug in file metadata modified timestamp returned by OS

### DIFF
--- a/fs-storage/src/base_storage.rs
+++ b/fs-storage/src/base_storage.rs
@@ -1,5 +1,5 @@
 use data_error::Result;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, time::SystemTime};
 
 #[derive(Debug, PartialEq, PartialOrd, Ord, Eq, Clone)]
 /// Represents the synchronization status of the storage.
@@ -54,7 +54,7 @@ pub trait BaseStorage<K, V>: AsRef<BTreeMap<K, V>> {
 
     /// Write the internal key-value mapping
     /// to pre-configured location in the filesystem.
-    fn write_fs(&mut self) -> Result<()>;
+    fn write_fs(&mut self) -> Result<SystemTime>;
 
     /// Erase data stored on the filesystem
     fn erase(&self) -> Result<()>;

--- a/fs-storage/src/file_storage.rs
+++ b/fs-storage/src/file_storage.rs
@@ -220,7 +220,7 @@ where
         match self.sync_status()? {
             SyncStatus::InSync => Ok(()),
             SyncStatus::MappingStale => self.read_fs().map(|_| ()),
-            SyncStatus::StorageStale => self.write_fs(),
+            SyncStatus::StorageStale => self.write_fs().map(|_| ()),
             SyncStatus::Diverge => {
                 let data = self.load_fs_data()?;
                 self.merge_from(&data)?;
@@ -243,7 +243,7 @@ where
     }
 
     /// Write the data to file
-    fn write_fs(&mut self) -> Result<()> {
+    fn write_fs(&mut self) -> Result<SystemTime> {
         let parent_dir = self.path.parent().ok_or_else(|| {
             ArklibError::Storage(
                 self.label.clone(),
@@ -261,14 +261,14 @@ where
             return Err("Timestamp has not been updated".into());
         }
         self.modified = new_timestamp;
-        self.written_to_disk = self.modified;
+        self.written_to_disk = new_timestamp;
 
         log::info!(
             "{} {} entries have been written",
             self.label,
             self.data.entries.len()
         );
-        Ok(())
+        Ok(new_timestamp)
     }
 
     /// Erase the file from disk
@@ -308,7 +308,7 @@ where
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::{collections::BTreeMap, fs};
     use tempdir::TempDir;
 
     use crate::{
@@ -392,8 +392,11 @@ mod tests {
             mirror_storage.sync_status().unwrap(),
             SyncStatus::StorageStale
         );
-        mirror_storage.write_fs().unwrap();
-        assert_eq!(mirror_storage.sync_status().unwrap(), SyncStatus::InSync);
+        let updated = mirror_storage.write_fs().unwrap();
+        let file_updated = fs::metadata(&mirror_storage.path).unwrap().modified().unwrap();
+        assert_eq!(file_updated, updated);
+        let file_updated_2 = fs::metadata(&mirror_storage.path).unwrap().modified().unwrap();
+        assert_eq!(file_updated, file_updated_2);
 
         assert_eq!(
             file_storage.sync_status().unwrap(),


### PR DESCRIPTION
The file metadata modified timestamp returns different values for reading the same file without any changes :exploding_head:. Which is causing the bug in #63.

This is a separate PR to discuss and debug it. Here's output from the modified test that's failing for me locally. It has two different timestamps for the same file even though there is no modification between the two readings.

```
---- file_storage::tests::test_file_storage_is_storage_updated stdout ----
thread 'file_storage::tests::test_file_storage_is_storage_updated' panicked at fs-storage/src/file_storage.rs:397:9:
assertion `left == right` failed
  left: SystemTime { tv_sec: 1717951936, tv_nsec: 537150997 }
 right: SystemTime { tv_sec: 1717951936, tv_nsec: 529151011 }
 ```
 
 Can others reproduce this locally as well?