### PR TITLE
Remove release build from linux ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Run tests
         run: cargo test --verbose
 
-      - name: Build Release
-        run: cargo build --verbose --release
-
   windows:
     name: Test on Windows
     runs-on: windows-latest


### PR DESCRIPTION
Remove linux release build as last step from github ci as it adds to build verification time.