### PR TITLE
fix: update deprecated macOS runners

### DIFF
--- a/.github/workflows/arkdrop-release.yml
+++ b/.github/workflows/arkdrop-release.yml
@@ -51,10 +51,10 @@ jobs:
             archive: zip
 
           # macOS targets
-          - os: macos-13
+          - os: macos-latest
             target: x86_64-apple-darwin
             archive: tar.gz
-          - os: macos-14
+          - os: macos-latest
             target: aarch64-apple-darwin
             archive: tar.gz
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       matrix:
         # We also run on macOS arm in the weekly workflow.
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4
@@ -66,7 +66,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest]
     needs: build-and-test
 
     steps:

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -45,27 +45,9 @@ jobs:
       - name: Run tests
         run: cargo test --workspace --verbose --release
 
-  mac-intel:
-    name: MacOS Intel
-    runs-on: macos-13
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Set up Cargo Cache
-        uses: Swatinem/rust-cache@v2
-        with:
-          save-if: true
-
-      - name: Run tests
-        run: cargo test --workspace --verbose --release
-
-  mac-arm:
-    name: MacOS ARM
-    runs-on: macos-14
+  macos:
+    name: MacOS
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/weekly.yml
+++ b/.github/workflows/weekly.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-13, macos-14]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Remove discontinued `macos-13` runner and use `macos-latest`, that can build both arm64 and Intel (x64) labels.

It fixes these timeout errors on CI runners:
<img width="659" height="72" alt="image" src="https://github.com/user-attachments/assets/c6b2bf59-5f3c-4cf5-bb16-044487ed943b" />
(https://github.com/ARK-Builders/ark-core/actions/runs/25556006005)